### PR TITLE
Arduino IDE v1.8.7 compatibility

### DIFF
--- a/package_multi_4in1_board_index.json
+++ b/package_multi_4in1_board_index.json
@@ -306,6 +306,27 @@
         }]
       },
       {
+        "name": "Multi 4-in-1 STM32 Board",
+        "architecture": "STM32F1",
+        "version": "1.1.0",
+        "category": "Contributed",
+        "help": {
+          "online": "https://github.com/pascallanger/DIY-Multiprotocol-TX-Module"
+        },
+        "url": "https://github.com/pascallanger/DIY-Multiprotocol-TX-Module-Boards/raw/master/archives/package_multi_4in1_stm32_board_v1.1.0.tar.gz",
+        "archiveFileName": "package_multi_4in1_stm32_board_v1.1.0.tar.gz",
+        "checksum": "SHA-256:919ece2021757686e6892679956dcb8a01c9308a152167d61d9204656b4ed7ee",
+        "size": "10333612",
+        "boards": [{
+          "name": "Multi 4-in-1 (STM32F103C)"
+        }],
+        "toolsDependencies": [{
+          "packager": "arduino",
+          "name": "arm-none-eabi-gcc",
+          "version": "4.8.3-2014q1"
+        }]
+      }, 
+     {
         "name": "Multi 4-in-1 OrangeRX Board - DEPRECATED, USE MULTI 4-IN-1 AVR BOARDS PACKAGE INSTEAD",
         "architecture": "orangerx",
         "version": "1.0.1",

--- a/source/package_multi_4in1_board_devel_index.json
+++ b/source/package_multi_4in1_board_devel_index.json
@@ -306,6 +306,27 @@
         }]
       },
       {
+        "name": "Multi 4-in-1 STM32 Board (Devel)",
+        "architecture": "STM32F1",
+        "version": "1.1.0",
+        "category": "Contributed",
+        "help": {
+          "online": "https://github.com/pascallanger/DIY-Multiprotocol-TX-Module"
+        },
+        "url": "https://github.com/pascallanger/DIY-Multiprotocol-TX-Module-Boards/raw/devel/archives/package_multi_4in1_stm32_board_v1.1.0.tar.gz",
+        "archiveFileName": "package_multi_4in1_stm32_board_v1.1.0.tar.gz",
+        "checksum": "SHA-256:919ece2021757686e6892679956dcb8a01c9308a152167d61d9204656b4ed7ee",
+        "size": "10333612",
+        "boards": [{
+          "name": "Multi 4-in-1 (STM32F103C)"
+        }],
+        "toolsDependencies": [{
+          "packager": "arduino",
+          "name": "arm-none-eabi-gcc",
+          "version": "4.8.3-2014q1"
+        }]
+      },
+      {
         "name": "Multi 4-in-1 OrangeRX Board - DEPRECATED, USE MULTI 4-IN-1 AVR BOARDS PACKAGE INSTEAD",
         "architecture": "orangerx",
         "version": "1.0.1",

--- a/source/stm32/boards.txt
+++ b/source/stm32/boards.txt
@@ -16,7 +16,7 @@ multistm32f103c.pid.0=0x0004
 multistm32f103c.build.variant=generic_stm32f103c
 multistm32f103c.build.vect=VECT_TAB_ADDR=0x8000000
 multistm32f103c.build.core=maple
-multistm32f103c.build.board=MULTI_STM32_FLASH_FROM_TX=109
+multistm32f103c.build.board=MULTI_STM32_FLASH_FROM_TX=110
 multistm32f103c.upload.use_1200bps_touch=false
 multistm32f103c.upload.file_type=bin
 multistm32f103c.upload.auto_reset=true
@@ -37,7 +37,7 @@ multistm32f103c.bootloader.tool=serial_upload
 #---------------------------- UPLOAD METHODS ---------------------------
 
 multistm32f103c.menu.upload_method.TxFlashMethod=Flash from Tx
-multistm32f103c.menu.upload_method.TxFlashMethod.build.board=MULTI_STM32_FLASH_FROM_TX=109
+multistm32f103c.menu.upload_method.TxFlashMethod.build.board=MULTI_STM32_FLASH_FROM_TX=110
 multistm32f103c.menu.upload_method.TxFlashMethod.upload.tool=tx_upload
 multistm32f103c.menu.upload_method.TxFlashMethod.build.upload_flags=-DSERIAL_USB -DGENERIC_BOOTLOADER
 multistm32f103c.menu.upload_method.TxFlashMethod.build.vect=VECT_TAB_ADDR=0x8002000
@@ -46,7 +46,7 @@ multistm32f103c.menu.upload_method.TxFlashMethod.bootloader.file=Multi4in1/StmMu
 multistm32f103c.menu.upload_method.TxFlashMethod.upload.maximum_size=120832
 
 multistm32f103c.menu.upload_method.AutoFlashMethod=Auto Detect (USB or Serial)
-multistm32f103c.menu.upload_method.AutoFlashMethod.build.board=MULTI_STM32_WITH_BOOT=109
+multistm32f103c.menu.upload_method.AutoFlashMethod.build.board=MULTI_STM32_WITH_BOOT=110
 multistm32f103c.menu.upload_method.AutoFlashMethod.upload.tool=auto_upload
 multistm32f103c.menu.upload_method.AutoFlashMethod.build.upload_flags=-DSERIAL_USB -DGENERIC_BOOTLOADER
 multistm32f103c.menu.upload_method.AutoFlashMethod.build.vect=VECT_TAB_ADDR=0x8002000
@@ -55,7 +55,7 @@ multistm32f103c.menu.upload_method.AutoFlashMethod.bootloader.file=Multi4in1/Stm
 multistm32f103c.menu.upload_method.AutoFlashMethod.upload.maximum_size=120832
 
 multistm32f103c.menu.upload_method.DFUUploadMethod=Upload via USB
-multistm32f103c.menu.upload_method.DFUUploadMethod.build.board=MULTI_STM32_NO_BOOT=109
+multistm32f103c.menu.upload_method.DFUUploadMethod.build.board=MULTI_STM32_NO_BOOT=110
 multistm32f103c.menu.upload_method.DFUUploadMethod.upload.protocol=maple_dfu
 multistm32f103c.menu.upload_method.DFUUploadMethod.upload.tool=maple_upload
 multistm32f103c.menu.upload_method.DFUUploadMethod.build.upload_flags=-DSERIAL_USB -DGENERIC_BOOTLOADER
@@ -67,7 +67,7 @@ multistm32f103c.menu.upload_method.DFUUploadMethod.bootloader.file=Multi4in1/Stm
 multistm32f103c.menu.upload_method.DFUUploadMethod.upload.maximum_size=120832
 
 multistm32f103c.menu.upload_method.serialIncBootloaderMethod=Upload via Serial inc. Bootloader (FTDI)
-multistm32f103c.menu.upload_method.serialIncBootloaderMethod.build.board=MULTI_STM32_WITH_BOOT=109
+multistm32f103c.menu.upload_method.serialIncBootloaderMethod.build.board=MULTI_STM32_WITH_BOOT=110
 multistm32f103c.menu.upload_method.serialIncBootloaderMethod.upload.protocol=maple_serial
 multistm32f103c.menu.upload_method.serialIncBootloaderMethod.upload.tool=serial_upload_inc_bootloader
 multistm32f103c.menu.upload_method.serialIncBootloaderMethod.build.upload_flags=-DSERIAL_USB -DGENERIC_BOOTLOADER
@@ -80,7 +80,7 @@ multistm32f103c.menu.upload_method.serialMethod=Upload via Serial (FTDI)
 multistm32f103c.menu.upload_method.serialMethod.upload.protocol=maple_serial
 multistm32f103c.menu.upload_method.serialMethod.upload.tool=serial_upload
 multistm32f103c.menu.upload_method.serialMethod.build.upload_flags=-DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG
-multistm32f103c.menu.upload_method.serialMethod.build.board=MULTI_STM32_NO_BOOT=109
+multistm32f103c.menu.upload_method.serialMethod.build.board=MULTI_STM32_NO_BOOT=110
 multistm32f103c.menu.upload_method.serialMethod.bootloader.file=Multi4in1/StmMulti4in1.bin
 
 ##############################################################

--- a/source/stm32/cores/maple/Arduino.h
+++ b/source/stm32/cores/maple/Arduino.h
@@ -29,11 +29,11 @@
 
 #include "wirish.h"
 
-void setup();
-void loop();
 #ifdef __cplusplus
 extern "C"{
 #endif // __cplusplus
+void setup();
+void loop();
 void yield(void);
 #ifdef __cplusplus
 }

--- a/source/stm32/cores/maple/main.cpp
+++ b/source/stm32/cores/maple/main.cpp
@@ -24,8 +24,14 @@
  * SOFTWARE.
  *****************************************************************************/
 
+ #ifdef __cplusplus
+extern "C"{
+#endif // __cplusplus
 extern void setup(void);
 extern void loop(void);
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 extern void init(void);
 
 // Force init to be called *first*, i.e. before static object allocation.

--- a/source/stm32/platform.txt
+++ b/source/stm32/platform.txt
@@ -6,7 +6,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5---3rd-party-Hardware-specification
 
 name=Multi 4-in-1 STM32
-version=1.0.9
+version=1.1.0
 
 compiler.warning_flags=-w -DDEBUG_LEVEL=DEBUG_NONE
 compiler.warning_flags.none=-w -DDEBUG_LEVEL=DEBUG_NONE


### PR DESCRIPTION
Fixing the definitions of `setup()` and `loop()` in the STM32F1 core so that they don't conflict with the Multiprotocol definitions when the Arduino IDE preprocessor parses them.